### PR TITLE
Fix Crash in Macro GUI and fix includeFluids Interpretation in quicktp

### DIFF
--- a/src/client/java/tools/redstone/redstonetools/malilib/widget/MacroBase.java
+++ b/src/client/java/tools/redstone/redstonetools/malilib/widget/MacroBase.java
@@ -56,7 +56,7 @@ public class MacroBase {
 	}
 
 	public MacroBase(String name, String keybind, List<CommandAction> actions, boolean enabled) {
-		this.actions = actions;
+		this.actions = new java.util.ArrayList<>(actions);
 		this.hotkey = new ConfigHotkey("hotkey", keybind, "Pressing this hotkey will activate the macro", "Hotkey");
 		this.hotkey.getKeybind().setCallback((t, g) -> {
 			this.run();

--- a/src/main/java/tools/redstone/redstonetools/features/commands/QuickTpFeature.java
+++ b/src/main/java/tools/redstone/redstonetools/features/commands/QuickTpFeature.java
@@ -38,7 +38,7 @@ public class QuickTpFeature extends AbstractFeature {
         catch (Exception ignored) {
             distance = 50.0;
         }
-        try { includeFluids = !BoolArgumentType.getBool(context, "throughFluids"); }
+        try { includeFluids = BoolArgumentType.getBool(context, "throughFluids"); }
         catch (Exception ignored) {
             includeFluids = false;
         }


### PR DESCRIPTION
Fixed the crash in the Macro GUI and made /quicktp <distance> <includefluids> only include fluids when <includefluids> = true 