### PR TITLE
Create temp directory and file if not exist

### DIFF
--- a/src/client/java/tools/redstone/redstonetools/utils/MappingUtils.java
+++ b/src/client/java/tools/redstone/redstonetools/utils/MappingUtils.java
@@ -55,6 +55,12 @@ public class MappingUtils {
 
 				var gzPath = mappingsPath.resolveSibling("temp.gz");
 				InputStream in = URI.create(url).toURL().openStream();
+
+				if (!Files.exists(gzPath)) {
+					Files.createDirectories(gzPath.getParent());
+					Files.createFile(gzPath);
+				}
+				
 				Files.copy(in, gzPath, StandardCopyOption.REPLACE_EXISTING);
 				GZIPInputStream gis = new GZIPInputStream(new FileInputStream(gzPath.toFile()));
 				FileOutputStream fos = new FileOutputStream(mappingsPath.toFile());


### PR DESCRIPTION
Ensure the temporary directory and file are created if they do not exist before copying the input stream.