### PR TITLE
feat: Added modular config classes & specified it to match previous '…

### DIFF
--- a/src/main/java/tools/redstone/redstonetools/RedstoneTools.java
+++ b/src/main/java/tools/redstone/redstonetools/RedstoneTools.java
@@ -4,6 +4,7 @@ package tools.redstone.redstonetools;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import tools.redstone.redstonetools.config.ServerConfig;
 import tools.redstone.redstonetools.packets.RedstoneToolsPackets;
 
 //~ if paper 'implements ModInitializer' -> 'extends JavaPlugin'
@@ -15,10 +16,20 @@ public class RedstoneTools extends JavaPlugin {
 	@Override
 	//~ if paper 'onInitialize' -> 'onEnable'
 	public void onEnable() {
+		registerConfig();
 		registerNetworking();
 		registerGameRules();
 		registerCommands();
 		registerListeners();
+	}
+
+	/** Server-side configuration. Fabric uses a shared config dir, Paper the plugin's folder. */
+	private void registerConfig() {
+		//? if fabric {
+		/*ServerConfig.load(net.fabricmc.loader.api.FabricLoader.getInstance().getConfigDir().resolve("redstonetools.properties"));
+		*///? } else {
+		ServerConfig.load(getDataFolder().toPath().resolve("config.yml"));
+		//? }
 	}
 
 	/** Feature toggle sync with the client mod. Fabric uses custom payloads, Paper plugin messaging. */

--- a/src/main/java/tools/redstone/redstonetools/config/ConfigInt.java
+++ b/src/main/java/tools/redstone/redstonetools/config/ConfigInt.java
@@ -1,0 +1,33 @@
+package tools.redstone.redstonetools.config;
+
+import tools.redstone.redstonetools.RedstoneTools;
+
+public class ConfigInt extends ConfigOption<Integer> {
+
+	private final int min;
+	private final int max;
+
+	public ConfigInt(String key, int defaultValue, int min, int max, String description) {
+		super(key, defaultValue, description);
+		this.min = min;
+		this.max = max;
+	}
+
+	@Override
+	protected Integer parse(String raw) {
+		int parsed;
+
+		try {
+			parsed = Integer.parseInt(raw.trim());
+		} catch (NumberFormatException ex) {
+			return null;
+		}
+
+		if (parsed < min || parsed > max) {
+			RedstoneTools.LOGGER.warn("Config key '{}' accepts {} to {}, clamping {}", key(), min, max, parsed);
+			return Math.clamp(parsed, min, max);
+		}
+
+		return parsed;
+	}
+}

--- a/src/main/java/tools/redstone/redstonetools/config/ConfigOption.java
+++ b/src/main/java/tools/redstone/redstonetools/config/ConfigOption.java
@@ -1,0 +1,52 @@
+package tools.redstone.redstonetools.config;
+
+import tools.redstone.redstonetools.RedstoneTools;
+
+public abstract class ConfigOption<T> {
+
+	private final String key;
+	private final String description;
+	private final T defaultValue;
+	private T value;
+
+	protected ConfigOption(String key, T defaultValue, String description) {
+		this.key = key;
+		this.defaultValue = defaultValue;
+		this.description = description;
+		this.value = defaultValue;
+	}
+
+	public String key() {
+		return key;
+	}
+
+	public String description() {
+		return description;
+	}
+
+	public T get() {
+		return value;
+	}
+
+	public void reset() {
+		this.value = defaultValue;
+	}
+
+	public String write() {
+		return String.valueOf(value);
+	}
+
+	public void read(String raw) {
+		T parsed = parse(raw);
+
+		if (parsed == null) {
+			RedstoneTools.LOGGER.warn("Invalid value '{}' for config key '{}', falling back to {}", raw, key, defaultValue);
+			this.value = defaultValue;
+			return;
+		}
+
+		this.value = parsed;
+	}
+
+	protected abstract T parse(String raw);
+}

--- a/src/main/java/tools/redstone/redstonetools/config/ServerConfig.java
+++ b/src/main/java/tools/redstone/redstonetools/config/ServerConfig.java
@@ -1,0 +1,137 @@
+package tools.redstone.redstonetools.config;
+
+import tools.redstone.redstonetools.RedstoneTools;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+//? if paper {
+import org.bukkit.configuration.file.YamlConfiguration;
+//? } else {
+/*import java.util.Properties;
+import java.io.Reader;
+*///? }
+
+public class ServerConfig {
+
+	public static final ConfigInt THAT_SIZE_LIMIT = new ConfigInt(
+		"that.size-limit", 200, 1, 10_000,
+		"Maximum size of the selection //that may produce, on any single axis, in blocks.");
+
+	public static final ConfigInt THAT_MAX_TIME_PER_TICK_MS = new ConfigInt(
+		"that.max-time-per-tick-ms", 30, 1, 45,
+		"""
+			How long //that may spend expanding a selection during a single tick, in milliseconds.
+			A server tick is 50ms, so values close to that will visibly lag the server.""");
+
+	public static final ConfigInt THAT_MAX_TICKS = new ConfigInt(
+		"that.max-ticks", 5, 1, 600,
+		"How many ticks //that may spend on one selection before giving up.");
+
+	public static final List<ConfigOption<?>> OPTIONS = List.of(
+		THAT_SIZE_LIMIT,
+		THAT_MAX_TIME_PER_TICK_MS,
+		THAT_MAX_TICKS);
+
+	public static void load(Path file) {
+		Map<String, String> raw = readRaw(file);
+
+		for (ConfigOption<?> option : OPTIONS) {
+			String value = raw.get(option.key());
+
+			if (value == null) {
+				option.reset();
+			} else {
+				option.read(value);
+			}
+		}
+
+		write(file);
+	}
+
+	//? if fabric {
+	/*private static Map<String, String> readRaw(Path file) {
+		Map<String, String> raw = new HashMap<>();
+		if (!Files.exists(file)) {
+			return raw;
+		}
+
+		Properties properties = new Properties();
+		try (Reader reader = Files.newBufferedReader(file)) {
+			properties.load(reader);
+		} catch (IOException ex) {
+			RedstoneTools.LOGGER.error("Could not read {}, using defaults", file, ex);
+			return raw;
+		}
+
+		for (ConfigOption<?> option : OPTIONS) {
+			String value = properties.getProperty(option.key());
+			if (value != null) {
+				raw.put(option.key(), value);
+			}
+		}
+
+		return raw;
+	}
+
+	private static void write(Path file) {
+		StringBuilder out = new StringBuilder();
+		out.append("# Redstone Tools server configuration.\n");
+		out.append("# Regenerated on every start: unknown keys are dropped, new ones appear with their default.\n");
+
+		for (ConfigOption<?> option : OPTIONS) {
+			out.append('\n');
+			for (String line : option.description().split("\n")) {
+				out.append("# ").append(line).append('\n');
+			}
+			out.append(option.key()).append('=').append(option.write()).append('\n');
+		}
+
+		try {
+			Files.createDirectories(file.getParent());
+			Files.writeString(file, out.toString());
+		} catch (IOException ex) {
+			RedstoneTools.LOGGER.error("Could not write {}", file, ex);
+		}
+	}
+	*///? } else {
+	private static Map<String, String> readRaw(Path file) {
+		Map<String, String> raw = new HashMap<>();
+		if (!Files.exists(file)) {
+			return raw;
+		}
+
+		YamlConfiguration config = YamlConfiguration.loadConfiguration(file.toFile());
+
+		for (ConfigOption<?> option : OPTIONS) {
+			if (config.contains(option.key())) {
+				raw.put(option.key(), String.valueOf(config.get(option.key())));
+			}
+		}
+
+		return raw;
+	}
+
+	private static void write(Path file) {
+		YamlConfiguration config = new YamlConfiguration();
+		config.options().setHeader(List.of(
+			"Redstone Tools server configuration.",
+			"Regenerated on every start: unknown keys are dropped, new ones appear with their default."));
+
+		for (ConfigOption<?> option : OPTIONS) {
+			config.set(option.key(), option.get());
+			config.setComments(option.key(), List.of(option.description().split("\n")));
+		}
+
+		try {
+			Files.createDirectories(file.getParent());
+			config.save(file.toFile());
+		} catch (IOException ex) {
+			RedstoneTools.LOGGER.error("Could not write {}", file, ex);
+		}
+	}
+	//? }
+}


### PR DESCRIPTION
Adds a server-side config file on both loaders. The first entries are the three limits `//that` needs, hence the `that.*` names. `//that` itself is the follow-up PR, nothing reads these keys yet.

`config.yml` in the plugin folder on Paper, `redstonetools.properties` in the config dir on Fabric. Same keys either way: `YamlConfiguration` treats `.` as a path separator, so `that.size-limit` is flat in one file and nested in the other from a single constant. Only the file IO forks. Reading returns `Map<String, String>` on both sides, so parsing and validation cannot drift apart.

**The file is rewritten on every start**, so new options reach servers that already have one. Unknown keys are dropped and manual formatting is lost.

Commits, oldest first:

- **Add a typed config option layer.** Key, default, description, bounds. Out-of-range values are clamped and logged, unparseable ones fall back to the default with a warning.
- **Add ServerConfig and load it on startup.** Comments in the generated file come from the option's description, so they cannot drift from the defaults.

Tested on Paper 26.1.2 and on Fabric 26.1.2 / 26.2 : file generated with its comments, edited values read back, bad values fall back as described. `./gradlew build` green on all eight targets.